### PR TITLE
Add header tag with mobile viewport and title

### DIFF
--- a/src/backend/app/blog.hoon
+++ b/src/backend/app/blog.hoon
@@ -140,7 +140,7 @@
               ~  %.n  %payload
               [200 ['Content-Type' 'text/html; charset=utf-8']~]
               =/  tem=@t  (~(gut by themes) theme.act '')
-              `(as-octs:mimes:html (cat 3 html.act (add-style:blog-lib tem)))
+              `(as-octs:mimes:html (cat 3 (cat 3 (add-header:blog-lib path.act) html.act) (add-style:blog-lib tem)))
       ==  ==
     ::
         %unpublish

--- a/src/backend/lib/blog.hoon
+++ b/src/backend/lib/blog.hoon
@@ -29,6 +29,16 @@
   ^-  @t
   (cat 3 (cat 3 '<style>' css) '</style>')
 ::
+++  add-header
+  |=  title=path
+  ^-  @t
+  %-  crip
+  """
+  <head>
+  <title>{(trip `@t`&1:title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+  """
+::
 ++  http-response-cards
   |=  [id=@tas hed=response-header:http data=(unit octs)]
   ^-  (list card:agent:gall)


### PR DESCRIPTION
### Mobile First
This magic <meta> tag keeps a design consistent across desktop to mobile.
`<meta name="viewport" content="width=device-width, initial-scale=1.0">`

Looking nice on mobile was the main reason for adding the <head> tag into %blog.
As a bonus, I also added a <title> tag that is pulled from the path given by `%blog-action`s.
The title is seen in the tabs of the browser. 

@bonbud-macryg We can expand this to include a favicon. You may enjoy designing one of those. 
It would look like adding `<link rel="icon" type="image/png" href="focus/assets/tile/png">`