### PR TITLE
Fix %rumors integration

### DIFF
--- a/src/frontend/src/components/BottomBar.tsx
+++ b/src/frontend/src/components/BottomBar.tsx
@@ -175,12 +175,12 @@ export default function BottomBar ({
 
       setPosts(pages.filter(item => item !== fileName))
       setDrafts(drafts.filter(item => item !== fileName))
-      navigate(`/published${fileName}`)
       getAll()
       if (await palsAndRumorsInstalled()) {
         setShowPublishModal(true)
       } else {
         setShowPublishModal(false)
+        navigate(`/published${fileName}`)
       }
     },
     [fileName, markdown, activeTheme]

--- a/src/frontend/src/components/Modal/Publish.tsx
+++ b/src/frontend/src/components/Modal/Publish.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Modal, type ModalProps } from './Modal'
 
 interface PublishModalProps extends ModalProps {
@@ -9,6 +10,8 @@ export default function Share ({ setShowModal, fileName }: PublishModalProps): J
   const [value, setValue] = useState(
     `AAAAH I'M GONNA %blog : ${window.location.origin}${fileName}`
   )
+  const navigate = useNavigate()
+
   return (
     <Modal>
       <h4 className='text-md font-bold mb-4'>
@@ -39,6 +42,7 @@ export default function Share ({ setShowModal, fileName }: PublishModalProps): J
             onClick={(e) => {
               e.preventDefault()
               setShowModal(false)
+              navigate(`/published${fileName}`)
             }}
           >
             Close


### PR DESCRIPTION
Hotfix for a bug with %rumors integration introduced in v0.2.1.

Splits the existing call to `navigate()` into two, which are called either 1) when the user publishes a post without having %pals and %rumors installed or 2) when they choose not to share a post to rumors. If they do choose to share a post to rumors, the existing behaviour takes them to the %rumors app.